### PR TITLE
Fixed undefined method error for Rails::Railtie::Configuration

### DIFF
--- a/lib/polymer-rails/railtie.rb
+++ b/lib/polymer-rails/railtie.rb
@@ -8,7 +8,9 @@ module Polymer
       end
 
       initializer :precompile_polymer do |app|
-        app.config.assets.precompile += %w( polymer/polymer.js )
+        if app.config.respond_to? (:assets)
+          app.config.assets.precompile += %w( polymer/polymer.js )
+        end
       end
 
       initializer :add_preprocessors do |app|


### PR DESCRIPTION
On Rails 3.2.X, rails g polymer:install gets this error.

railties-3.2.14/lib/rails/railtie/configuration.rb:85:in `method_missing': undefined method `assets' for #<Rails::Railtie::Configuration:0x00000103bbd808> (NoMethodError)