### PR TITLE
limiting sprockets version < 3.0.0

### DIFF
--- a/polymer-rails.gemspec
+++ b/polymer-rails.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rails",    ">= 3.1.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.6"
   spec.add_runtime_dependency "nokogumbo", "~> 1.1"
+  spec.add_runtime_dependency "sprockets", "< 3.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake",    "~> 0"


### PR DESCRIPTION
The recently released Sprockets 3.0.0 no longer has the Sprockets::Processor class. So the gemspec must limit sprockets version < 3.0.0 until the new interface is adopted.